### PR TITLE
TestControl: Configure RunAs='Interactive User'

### DIFF
--- a/TestControl/AppID.rgs
+++ b/TestControl/AppID.rgs
@@ -5,6 +5,7 @@ HKCR
 		ForceRemove '%APPID%' = s 'TestControl Object'
 		{
 			val DllSurrogate = s ''
+			val RunAs = s 'Interactive User'
 		}
 	}
 }


### PR DESCRIPTION
Done to allow medium IL clients to connect to an already running high IL server. Fixes #7.