### PR TITLE
TestControl: Remove abandoned support for building as DLL.

### DIFF
--- a/TestControl/AppID.rgs
+++ b/TestControl/AppID.rgs
@@ -4,7 +4,6 @@ HKCR
     {
         ForceRemove '%APPID%' = s 'TestControl Object'
         {
-            val DllSurrogate = s ''
         }
     }
 }

--- a/TestControl/Main.cpp
+++ b/TestControl/Main.cpp
@@ -4,14 +4,6 @@
 #include "ComSupport.hpp"
 #include <psapi.h>
 
-#ifdef _WINDLL
-class TestControlModule : public ATL::CAtlDllModuleT<TestControlModule> {
-public:
-    DECLARE_LIBID(LIBID_TestControl)
-    DECLARE_REGISTRY_APPID_RESOURCEID(IDR_AppID, "{264FBADA-8FEF-44B7-801E-B728A1749B5A}")
-};
-
-#else
 
 class TestControlModule : public ATL::CAtlExeModuleT<TestControlModule> {
 public:
@@ -32,74 +24,10 @@ public:
         return hr;
     }
 };
-#endif
 
 TestControlModule _AtlModule;
 
 
-#ifdef _WINDLL
-// DLL Entry Point
-extern "C" BOOL WINAPI DllMain(HINSTANCE /*hInstance*/, DWORD dwReason, LPVOID lpReserved) {
-    if (dwReason == DLL_PROCESS_ATTACH) {
-#if 0
-        // break dllhost.exe until debugger is attached
-        HANDLE process = GetCurrentProcess();
-        TCHAR filename[MAX_PATH] = {};
-        GetProcessImageFileName(process, filename, MAX_PATH);
-        if (std::string(filename).find("dllhost.exe") != std::string::npos) {
-            while (!IsDebuggerPresent())
-                Sleep(200);
-        }
-#endif
-    }
-
-    return _AtlModule.DllMain(dwReason, lpReserved);
-}
-
-// Used to determine whether the DLL can be unloaded by OLE.
-STDAPI DllCanUnloadNow() {
-    return _AtlModule.DllCanUnloadNow();
-}
-
-// Returns a class factory to create an object of the requested type.
-_Check_return_
-STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID* ppv) {
-    return _AtlModule.DllGetClassObject(rclsid, riid, ppv);
-}
-
-// DllRegisterServer - Adds entries to the system registry.
-STDAPI DllRegisterServer() {
-    // registers object, typelib and all interfaces in typelib
-    return _AtlModule.DllRegisterServer();
-}
-
-// DllUnregisterServer - Removes entries from the system registry.
-STDAPI DllUnregisterServer() {
-    return _AtlModule.DllUnregisterServer();
-}
-
-// DllInstall - Adds/Removes entries to the system registry per user per machine.
-STDAPI DllInstall(BOOL bInstall, _In_opt_  LPCWSTR pszCmdLine) {
-    static const wchar_t szUserSwitch[] = L"user";
-
-    if (pszCmdLine != NULL) {
-        if (_wcsnicmp(pszCmdLine, szUserSwitch, _countof(szUserSwitch)) == 0)
-            ATL::AtlSetPerUserRegistration(true);
-    }
-
-    HRESULT hr = E_FAIL;
-    if (bInstall) {
-        hr = DllRegisterServer();
-        if (FAILED(hr))
-            DllUnregisterServer();
-    } else {
-        hr = DllUnregisterServer();
-    }
-
-    return hr;
-}
-
-#else
 
 // EXE Entry Point
 int wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, wchar_t* /*lpCmdLine*/, int nShowCmd/*=SW_SHOWDEFAULT*/) {
@@ -111,4 +39,3 @@ int wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, wchar_t* /*lp
 
     return _AtlModule.WinMain(nShowCmd);
 }
-#endif

--- a/TestControl/Module.def
+++ b/TestControl/Module.def
@@ -1,6 +1,0 @@
-EXPORTS
-    DllCanUnloadNow     PRIVATE
-    DllGetClassObject   PRIVATE
-    DllRegisterServer   PRIVATE
-    DllUnregisterServer PRIVATE
-    DllInstall          PRIVATE

--- a/TestControl/TestControl.vcxproj
+++ b/TestControl/TestControl.vcxproj
@@ -22,7 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="AppID.rgs" />
-    <None Include="Module.def" />
     <None Include="TestControl.rgs" />
   </ItemGroup>
   <ItemGroup>
@@ -86,17 +85,10 @@
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>IF $(ConfigurationType) == DynamicLibrary (
-  echo Registering DLL...
-  regsvr32 /s "$(TargetPath)"
-) ELSE (
-  echo Registering EXE...
-  "$(TargetPath)" /regserver
-)
-echo [done]</Command>
+      <Command>"$(TargetPath)" /regserver</Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>Post-build registration</Message>
+      <Message>Registering COM EXE</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -121,17 +113,10 @@ echo [done]</Command>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>IF $(ConfigurationType) == DynamicLibrary (
-  echo Registering DLL...
-  regsvr32 /s "$(TargetPath)"
-) ELSE (
-  echo Registering EXE...
-  "$(TargetPath)" /regserver
-)
-echo [done]</Command>
+      <Command>"$(TargetPath)" /regserver</Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>Post-build registration</Message>
+      <Message>Registering COM EXE</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/TestControl/TestControl.vcxproj.filters
+++ b/TestControl/TestControl.vcxproj.filters
@@ -13,7 +13,6 @@
   <ItemGroup>
     <None Include="AppID.rgs" />
     <None Include="TestControl.rgs" />
-    <None Include="Module.def" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestControl.idl" />


### PR DESCRIPTION
DLL-based builds haven't been maintained, so I think it's better to just drop support so that the impl. can be simplified.

Sample code for COM DLL's in C++ and C#: https://github.com/forderud/ComSamples
