### PR TITLE
Add new AppContainerSid project

### DIFF
--- a/AppContainerSid/.gitignore
+++ b/AppContainerSid/.gitignore
@@ -1,0 +1,2 @@
+/x64
+/*.vcxproj.user

--- a/AppContainerSid/AppContainerSid.vcxproj
+++ b/AppContainerSid/AppContainerSid.vcxproj
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{a6741fdc-1165-4ac3-a026-8c01548e7275}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/AppContainerSid/AppContainerSid.vcxproj.filters
+++ b/AppContainerSid/AppContainerSid.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+</Project>

--- a/AppContainerSid/Main.cpp
+++ b/AppContainerSid/Main.cpp
@@ -1,7 +1,39 @@
 #include <Windows.h>
+#include <userenv.h>
 #include <iostream>
+#include "../RunInSandbox/Sandboxing.hpp"
+
+#pragma comment(lib, "Userenv.lib") // for DeriveAppContainerSidFromAppContainerName
+
 
 int wmain(int argc, wchar_t* argv[]) {
-    wprintf(L"Hello World!\n");
+    if (argc < 2) {
+        wprintf(L"Tool for determining the SID for a given AppContainer.\n");
+        wprintf(L"USAGE: AppContainerSid.exe <AppContainer-name>\n");
+        return -1;
+    }
+    
+    std::wstring appContainer = argv[1];
+
+    // DOC: https://devblogs.microsoft.com/oldnewthing/20220502-00/?p=106550
+    SidWrap sid;
+    HRESULT hr = DeriveAppContainerSidFromAppContainerName(appContainer.c_str(), &sid);
+    if (FAILED(hr)) {
+        _com_error err(hr);
+        wprintf(L"ERROR: Unable to convert AppContainer SID (%s).\n", err.ErrorMessage());
+        return -2;
+    }
+
+    // convert SID to string representation in "S-1-15-2-x1-x2-x3-x4-x5-x6-x7" format,
+    // where x1-x7 are the first 28 bytes of the SHA256 hash of the app name.
+    LocalWrap<wchar_t*> sid_str_buf;
+    BOOL ok = ConvertSidToStringSidW(sid, &sid_str_buf);
+    if (!ok) {
+        DWORD err = GetLastError();
+        wprintf(L"ERROR: Unable to convert AppContainer SID to string (%u).\n", err);
+        return -3;
+    }
+
+    wprintf(L"%s\n", (wchar_t*)sid_str_buf);
     return 0;
 }

--- a/AppContainerSid/Main.cpp
+++ b/AppContainerSid/Main.cpp
@@ -1,0 +1,7 @@
+#include <Windows.h>
+#include <iostream>
+
+int wmain(int argc, wchar_t* argv[]) {
+    wprintf(L"Hello World!\n");
+    return 0;
+}

--- a/RunInSandbox.sln
+++ b/RunInSandbox.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RunInSandboxNet", "RunInSan
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ComRunAs", "ComRunAs\ComRunAs.vcxproj", "{E145C919-E044-4028-99EF-B1A3236F2E26}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AppContainerSid", "AppContainerSid\AppContainerSid.vcxproj", "{A6741FDC-1165-4AC3-A026-8C01548E7275}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -60,6 +62,10 @@ Global
 		{E145C919-E044-4028-99EF-B1A3236F2E26}.Debug|x64.Build.0 = Debug|x64
 		{E145C919-E044-4028-99EF-B1A3236F2E26}.Release|x64.ActiveCfg = Release|x64
 		{E145C919-E044-4028-99EF-B1A3236F2E26}.Release|x64.Build.0 = Release|x64
+		{A6741FDC-1165-4AC3-A026-8C01548E7275}.Debug|x64.ActiveCfg = Debug|x64
+		{A6741FDC-1165-4AC3-A026-8C01548E7275}.Debug|x64.Build.0 = Debug|x64
+		{A6741FDC-1165-4AC3-A026-8C01548E7275}.Release|x64.ActiveCfg = Release|x64
+		{A6741FDC-1165-4AC3-A026-8C01548E7275}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Simple command-line tool for computing the SID for a given AppContainer.

Example usage:
```
> AppContainerSid.exe MyAppContainer
S-1-15-2-205019450-4040837878-416234186-1899422632-1581525045-2103561684-315921252
```
