### PR TITLE
Simplify SetTokenInformation TokenIntegrityLevel calls

### DIFF
--- a/RunInSandbox/Sandboxing.hpp
+++ b/RunInSandbox/Sandboxing.hpp
@@ -511,7 +511,7 @@ struct ImpersonateThread {
         TOKEN_MANDATORY_LABEL tml = {};
         tml.Label.Attributes = SE_GROUP_INTEGRITY;
         tml.Label.Sid = impersonation_sid;
-        WIN32_CHECK(SetTokenInformation(m_token.Get(), TokenIntegrityLevel, &tml, sizeof(tml) + GetLengthSid(impersonation_sid)));
+        WIN32_CHECK(SetTokenInformation(m_token.Get(), TokenIntegrityLevel, &tml, sizeof(tml)));
     }
 
     static HandleWrap GetShellProc() {

--- a/RunInSandboxNet/Sandboxing.cs
+++ b/RunInSandboxNet/Sandboxing.cs
@@ -31,7 +31,7 @@ class Sandboxing
             // reduce integrity level
             var tokenMandatoryLabel = new TOKEN_MANDATORY_LABEL(sidPtr);
             int TokenIntegrityLevel = 25; // from TOKEN_INFORMATION_CLASS enum
-            if (!SetTokenInformation(token, TokenIntegrityLevel, tokenMandatoryLabel, Marshal.SizeOf(tokenMandatoryLabel) + GetLengthSid(sidPtr)))
+            if (!SetTokenInformation(token, TokenIntegrityLevel, tokenMandatoryLabel, Marshal.SizeOf(tokenMandatoryLabel)))
                 throw new Win32Exception("SetTokenInformationStruct failed");
 
             Marshal.FreeHGlobal(sidPtr); // LocalFree wrapper
@@ -76,7 +76,4 @@ class Sandboxing
 
     [DllImport("Advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
     private static extern bool ConvertStringSidToSidW(string sid, out IntPtr psid);
-
-    [DllImport("Advapi32.dll")]
-    private static extern int GetLengthSid(IntPtr pSid);
 }


### PR DESCRIPTION
Stopp adding the SID length to the `TOKEN_MANDATORY_LABEL` struct length. I don't rember why this was done in the original code introduced in back in 11af3dc1917fcb17b818dc326c77061f4521925e, but I suspect that it have never been needed.

I've already tested by the change by starting notepad in a low, medium and high IL.