### PR TITLE
Move -b & -g arguments before ProogID or ExePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Sample C++ project for launching executables and out-of-process COM servers in a
 Related project: Microsoft [SandboxSecurityTools](https://github.com/microsoft/SandboxSecurityTools) for testing of AppContainer Sandboxing.
 
 ## RunInSandbox - Executable sandboxing
-Run `RunInSandbox.exe [ac|li|mi|hi] [-b] ExePath` to launch the `ExePath` application in an AppContainer, low IL, medium IL or high IL process. This works for `STARTUPINFOEX`-based process creation. The `-b` option is used to break execution immediately after process creation to enable debugging of startup problems.
+Run `RunInSandbox.exe [ac|li|mi|hi] [-b] ExePath <arguments>` to launch the `ExePath` application in an AppContainer, low IL, medium IL or high IL process. This works for `STARTUPINFOEX`-based process creation. The `-b` option is used to break execution immediately after process creation to enable debugging of startup problems.
 
 ## RunInSandbox - COM sandboxing
 Run `RunInSandbox.exe [ac|li|mi|hi] [-g][-b] ProgID` to launch the `ProgID` COM server in an AppContainer, low IL, medium IL or high IL process. The `-g` option is used to grant AppContainer permissions for the COM server, which only need to be done once.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Sample C++ project for launching executables and out-of-process COM servers in a
 Related project: Microsoft [SandboxSecurityTools](https://github.com/microsoft/SandboxSecurityTools) for testing of AppContainer Sandboxing.
 
 ## RunInSandbox - Executable sandboxing
-Run `RunInSandbox.exe [ac|li|mi|hi] ExePath [-b]` to launch the `ExePath` application in an AppContainer, low IL, medium IL or high IL process. This works for `STARTUPINFOEX`-based process creation. The `-b` option is used to break execution immediately after process creation to enable debugging of startup problems.
+Run `RunInSandbox.exe [ac|li|mi|hi] [-b] ExePath` to launch the `ExePath` application in an AppContainer, low IL, medium IL or high IL process. This works for `STARTUPINFOEX`-based process creation. The `-b` option is used to break execution immediately after process creation to enable debugging of startup problems.
 
 ## RunInSandbox - COM sandboxing
-Run `RunInSandbox.exe [ac|li|mi|hi] ProgID [-g][-b]` to launch the `ProgID` COM server in an AppContainer, low IL, medium IL or high IL process. The `-g` option is used to grant AppContainer permissions for the COM server, which only need to be done once.
+Run `RunInSandbox.exe [ac|li|mi|hi] [-g][-b] ProgID` to launch the `ProgID` COM server in an AppContainer, low IL, medium IL or high IL process. The `-g` option is used to grant AppContainer permissions for the COM server, which only need to be done once.
 
 Example usage:
 * `RunInSandbox.exe ac TestControl.TestControl -g` to start the TestControl project in a AppContainer process and test its COM API.

--- a/RunInSandbox/Main.cpp
+++ b/RunInSandbox/Main.cpp
@@ -174,7 +174,7 @@ int wmain (int argc, wchar_t *argv[]) {
     if (argc < 2) {
         std::wcerr << L"Too few arguments\n.";
         std::wcerr << L"Usage: RunInSandbox.exe [ac|li|mi|hi] [-g] [-b] ProgID\n";
-        std::wcerr << L"Usage: RunInSandbox.exe [ac|li|mi|hi] [-b] ExePath|URL\n";
+        std::wcerr << L"Usage: RunInSandbox.exe [ac|li|mi|hi] [-b] ExePath|URL <arguments>\n";
         return -1;
     }
 

--- a/RunInSandbox/Main.cpp
+++ b/RunInSandbox/Main.cpp
@@ -173,8 +173,8 @@ static void ComTests (CLSID clsid, IntegrityLevel mode, bool break_at_startup, b
 int wmain (int argc, wchar_t *argv[]) {
     if (argc < 2) {
         std::wcerr << L"Too few arguments\n.";
-        std::wcerr << L"Usage: RunInSandbox.exe [ac|li|mi|hi] ProgID [-g]\n";
-        std::wcerr << L"Usage: RunInSandbox.exe [ac|li|mi|hi] ExePath|URL\n";
+        std::wcerr << L"Usage: RunInSandbox.exe [ac|li|mi|hi] [-g] [-b] ProgID\n";
+        std::wcerr << L"Usage: RunInSandbox.exe [ac|li|mi|hi] [-b] ExePath|URL\n";
         return -1;
     }
 
@@ -185,13 +185,7 @@ int wmain (int argc, wchar_t *argv[]) {
     if (mode != IntegrityLevel::Default)
         arg_idx++;
 
-    // check if 1st argument is a COM class ProgID
-    CLSID clsid = {};
-    std::wstring progid = argv[arg_idx];
-    bool progid_provided = SUCCEEDED(CLSIDFromProgID(progid.c_str(), &clsid));
-    bool url_provided = std::wstring(argv[arg_idx]).substr(0, 4) == L"http";
-    arg_idx++;
-
+    // check for -g and -b arguments
     bool break_at_startup = false;
     bool grant_appcontainer_permissions = false;
     while (arg_idx < argc) {
@@ -199,9 +193,18 @@ int wmain (int argc, wchar_t *argv[]) {
             grant_appcontainer_permissions = true;
         } else if (std::wstring(argv[arg_idx]) == L"-b") {
             break_at_startup = true;
+        } else {
+            break;
         }
         arg_idx++;
     }
+
+    // check if next argument is a COM class ProgID
+    CLSID clsid = {};
+    std::wstring progid = argv[arg_idx];
+    bool progid_provided = SUCCEEDED(CLSIDFromProgID(progid.c_str(), &clsid));
+    bool url_provided = std::wstring(argv[arg_idx]).substr(0, 4) == L"http";
+    arg_idx++;
 
     if (progid_provided) {
         // initialize single-threaded COM apartment with OLE support


### PR DESCRIPTION
Done to allow passing of EXE startup arguments _after_ ExePath. Also, document support for command-line argument passing.
